### PR TITLE
Fix Python3 download regex/path(was dmg, now pkg), add codeSigVerification to download recipe, new .install recipe

### DIFF
--- a/Python3/Python3.download.recipe
+++ b/Python3/Python3.download.recipe
@@ -12,14 +12,14 @@
 		<string>Python3</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>0.3.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;https:\/\/www\.python\.org\/ftp\/python\/3\.\d+\.\d+\/python-3\.\d+.\d+-macosx10\.6\.dmg)</string>
+				<string>(https://.*/python-3[a-z0-9\.\-]+\.pkg)</string>
 				<key>result_output_var_name</key>
 				<string>url</string>
 				<key>url</key>
@@ -32,7 +32,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<string>%NAME%.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -40,6 +40,21 @@
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.pkg</string>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: Ned Deily (DJ3H93M7VJ)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+			</dict>
 		</dict>
 	</array>
 </dict>

--- a/Python3/Python3.install.recipe
+++ b/Python3/Python3.install.recipe
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Installs the current release version of Python3.</string>
+	<key>Identifier</key>
+	<string>com.github.scriptingosx.install.Python3</string>
+	<key>Input</key>
+	<dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.4.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.scriptingosx.download.Python3</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>Installer</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.pkg</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
URLTextSearcher Processor part of download recipe was failing due to switch from dmg to pkg distribution, added codeSignatureVerification on downloaded .pkg.
(Note: similar to tarball signing for the PSF, they're using an individual’s key, but at least that’s stated officially - Ned shows up [here](https://www.python.org/downloads/), so seems legit).
Added install recipe just ‘cause 😅, bumped recipe version to incorporate new req.s