### PR TITLE
Fix DjView and LaTeXiT downloads

### DIFF
--- a/DjView/DjView.download.recipe
+++ b/DjView/DjView.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>DjView</string>
 		<key>SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;http://sourceforge\.net/projects/djvu/files/DjVuLibre_MacOS/(?P&lt;version&gt;.*?)/DjVuLibre-.*?.dmg)</string>
+		<string>(?P&lt;url&gt;https*://sourceforge\.net/projects/djvu/files/DjVuLibre_MacOS/(?P&lt;version&gt;.*?)/DjVuLibre-.*?.dmg)</string>
 		<key>SEARCH_URL</key>
 		<string>http://sourceforge.net/projects/djvu/rss?path=/DjVuLibre_MacOS</string>
 	</dict>

--- a/DjView/DjViewURLProvider.py
+++ b/DjView/DjViewURLProvider.py
@@ -8,7 +8,7 @@ from autopkglib import Processor, ProcessorError
 __all__ = ["DjViewURLProvider"]
 
 search_url = 'http://sourceforge.net/projects/djvu/rss?path=/DjVuLibre_MacOS'
-re_pattern = '(?P<url>http://sourceforge\.net/projects/djvu/files/DjVuLibre_MacOS/(?P<version>.*?)/DjVuLibre-.*?.dmg)'
+re_pattern = '(?P<url>https*://sourceforge\.net/projects/djvu/files/DjVuLibre_MacOS/(?P<version>.*?)/DjVuLibre-.*?.dmg)'
 #re_url = '(?P<url>https://.*/python-(?P<version>3\.\d+\.\d+).*\.pkg)'
 
 class DjViewURLProvider(Processor):
@@ -41,15 +41,15 @@ class DjViewURLProvider(Processor):
                         content = f.read()
                         f.close()
                 except BaseException as e:
-                        raise ProcessorError('Could not retrieve URL: %s' % index_url)
+                        raise ProcessorError('Could not retrieve URL: %s' % url)
 
                 re_pattern = re.compile(r'%s' % re_pattern)
 
                 m = re_pattern.search(content)
                 if not m:
                     raise ProcessorError(
-                    "Couldn't find download URL in %s"
-                    % (index_url))
+                    "Couldn't find download URL pattern (%s) in %s"
+                    % (re_pattern.pattern, url))
 
                 return { 'url': m.group("url"), 'version': m.group("version") }
 

--- a/LaTeXiT/LaTeXiT.download.recipe
+++ b/LaTeXiT/LaTeXiT.download.recipe
@@ -28,6 +28,11 @@
 				<string>%SEARCH_PATTERN%</string>
 				<key>url</key>
 				<string>%SEARCH_URL%</string>
+				<key>request_headers</key>
+				<dict>
+					<key>User-Agent</key>
+					<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/600.8.9 (KHTML, like Gecko) Version/8.0.8 Safari/600.8.9</string>
+				</dict>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>


### PR DESCRIPTION
- SourceForge now has HTTPS download links, so the URL patterns need to be changed to match both HTTP and HTTPS.
- LaTeXiT appears to have recently added a User-Agent filter to its website