### PR TITLE
Update VMwareHorizonClient.download.recipe

### DIFF
--- a/VMwareHorizonClient/VMwareHorizonClient.download.recipe
+++ b/VMwareHorizonClient/VMwareHorizonClient.download.recipe
@@ -11,9 +11,9 @@
 		<key>NAME</key>
 		<string>VMware-Horizon-Client</string>
 		<key>SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;https://download3\.vmware\.com/software/view/viewclients/CART\d\dQ\d_\d/VMware-Horizon-Client-(?P&lt;version&gt;[\d\.\-]+)\.dmg)</string>
+		<string>(?P&lt;url&gt;https://download3\.vmware\.com/software/view/viewclients/CART\d\dQ\d/VMware-Horizon-Client-(?P&lt;version&gt;[\d\.\-]+)\.dmg)</string>
 		<key>SEARCH_URL</key>
-		<string>https://my.vmware.com/web/vmware/details?downloadGroup=VIEWCLIENTS_MAC_352&amp;productId=421&amp;rPId=8672</string>
+		<string>https://my.vmware.com/web/vmware/details?downloadGroup=CART16Q2_MAC_410&amp;productId=578&amp;rPId=11463</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.2</string>


### PR DESCRIPTION
The regex for the `SEARCH_PATTERN` value needed to be updated and the `SEARCH_URL` value needed to be updated. This recipe should now pull VMware Horizon View 4.x.