### PR TITLE
Update VMwareHorizonClient.download.recipe

### DIFF
--- a/VMwareHorizonClient/VMwareHorizonClient.download.recipe
+++ b/VMwareHorizonClient/VMwareHorizonClient.download.recipe
@@ -13,7 +13,7 @@
 		<key>SEARCH_PATTERN</key>
 		<string>(?P&lt;url&gt;https://download3\.vmware\.com/software/view/viewclients/CART\d\dQ\d/VMware-Horizon-Client-(?P&lt;version&gt;[\d\.\-]+)\.dmg)</string>
 		<key>SEARCH_URL</key>
-		<string>https://my.vmware.com/web/vmware/details?downloadGroup=CART16Q2_MAC_410&amp;productId=578&amp;rPId=11463</string>
+		<string>https://my.vmware.com/web/vmware/details?productId=578&amp;rPId=114638&amp;downloadGroup=CART16Q3_MAC_420</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.2</string>


### PR DESCRIPTION
`Search_URL` address needed to be updated for the VMware Horizon 4.2.0 client's new address:

[https://my.vmware.com/web/vmware/details?productId=578&rPId=11463&downloadGroup=CART16Q3_MAC_420](https://my.vmware.com/web/vmware/details?productId=578&rPId=11463&downloadGroup=CART16Q3_MAC_420)