### PR TITLE
Corrected Parent Recipe Name

### DIFF
--- a/Fetch/Fetch.jss.recipe
+++ b/Fetch/Fetch.jss.recipe
@@ -28,7 +28,7 @@
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.jleggat.Fetch.pkg</string>
+	<string>com.github.jleggat.pkg.Fetch</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Recipe was failing due to Parent Recipe not existing.  This was because of a name change or possible typo.