### PR TITLE
Python.org packages have incorrect versions

### DIFF
--- a/Python3/Python3.munki.recipe
+++ b/Python3/Python3.munki.recipe
@@ -35,6 +35,60 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>flat_pkg_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack</string>
+			</dict>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/Python_Applications.pkg/Payload</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%/payload</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Python 3.6/Python Launcher.app</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/unpack</string>
+					<string>%RECIPE_CACHE_DIR%/payload</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+			<key>Arguments</key>
+			<dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 				<key>repo_subdirectory</key>

--- a/Python3/Python3.munki.recipe
+++ b/Python3/Python3.munki.recipe
@@ -49,7 +49,7 @@
 				<key>pkg_payload_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/Python_Applications.pkg/Payload</string>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload</string>
+				<string>%RECIPE_CACHE_DIR%/payload/Applications</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgPayloadUnpacker</string>
@@ -58,10 +58,10 @@
 			<key>Arguments</key>
 			<dict>
 				<key>faux_root</key>
-				<string>%RECIPE_CACHE_DIR%/payload</string>
+				<string>%RECIPE_CACHE_DIR%/payload/</string>
 				<key>installs_item_paths</key>
 				<array>
-					<string>/Python 3.6/Python Launcher.app</string>
+					<string>/Applications/Python 3.6/Python Launcher.app</string>
 				</array>
 			</dict>
 			<key>Processor</key>


### PR DESCRIPTION
If you check out http://bugs.python.org/issue24502
the python.org mac packages are being built as metapackages, and unfortunately the contained packages all have version=0.

This causes the python3.munki recipe to create a receipts array of four items that all have the incorrect version number of 0.

Unfortunately, it seems like this issue has been open with the maintainer for awhile, and he seems to think it would be better to just provide an "app installer", although it doesn't seem like they have anyone idea how to pull that off.

I'll mention on that issue that it really just needs to have the versions included, but feel free to jump on there and educate!

Regardless, until then, I updated the python3 recipe to unpack the metapackage and then create an installs item from the Python Launcher app.

I'm sure there's a better way to do this, but this got it done for me for the time being.