### PR TITLE
Opened up the re_pattern for VMwareHorizonClient.download

### DIFF
--- a/VMwareHorizonClient/VMwareHorizonClient.download.recipe
+++ b/VMwareHorizonClient/VMwareHorizonClient.download.recipe
@@ -11,9 +11,9 @@
 		<key>NAME</key>
 		<string>VMware-Horizon-Client</string>
 		<key>SEARCH_PATTERN_PRODUCT_VERSION</key>
-		<string>/web/vmware/details\?downloadGroup=CART\d\dQ\d_MAC_[0-9]+&amp;productId=[0-9]+&amp;rPId=[0-9]+</string>
+		<string>/web/vmware/details\?downloadGroup=CART.*_MAC_[0-9]+&amp;productId=[0-9]+&amp;rPId=[0-9]+</string>
 		<key>SEARCH_PATTERN_DMG</key>
-		<string>https://download3.vmware.com/software/view/viewclients/CART\d\dQ\d/VMware-Horizon-Client-[\d\.\-]+\.dmg</string>
+		<string>https://download3.vmware.com/software/view/viewclients/CART.*/VMware-Horizon-Client-[\d\.\-]+\.dmg</string>
 		<key>SEARCH_URL_PRODUCT_VERSION</key>
 		<string>https://my.vmware.com/en/web/vmware/info/slug/desktop_end_user_computing/vmware_horizon_clients/4_0</string>
 	</dict>


### PR DESCRIPTION
I slightly broadened out the pattern match criteria for VMwareHorizonClient.download, as the Cart code had changed so that there was no match with `\d\dQ\d` anymore. It seems to be fine with `.*`.