### PR TITLE
Munkiimport package wasn't working... fixed it....

### DIFF
--- a/DjView/DjView.munki.recipe
+++ b/DjView/DjView.munki.recipe
@@ -40,6 +40,8 @@ DjVuLibre is an open source (GPL'ed) implementation of DjVu, including viewers, 
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>


### PR DESCRIPTION
AutoPkg was throwing the following error:

> The following recipes failed:
>     DjView.munki.recipe
>         MunkiImporter requires missing argument pkg_path
> 

I added a pkg_path from another recipe and tested and it is working fine.  

There is a filename problem but this is coming from the developer:

The DMG file is named "DjView-3.5.27%2B4.10.dmg" this is because the developer on source forge names their download "DjVuLibre-3.5.27+DjView-4.10.6-qt57c-intel64.dmg".   The plist shows DjView 4.10 as the version number and the file in the repo shows a version of 3.5.27 as it's two products rolled into one.  


