### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/DjView/DjView.pkg.recipe
+++ b/DjView/DjView.pkg.recipe
@@ -18,7 +18,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>app_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/DjView.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>

--- a/Fetch/Fetch_old.pkg.recipe
+++ b/Fetch/Fetch_old.pkg.recipe
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+                <string>%pathname%/Fetch.app/Contents/Info.plist</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleVersion</key>
@@ -62,9 +62,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Fetch.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Fetch.app</string>
             </dict>
         </dict>
         <dict>

--- a/FileZilla/FileZilla.pkg.recipe
+++ b/FileZilla/FileZilla.pkg.recipe
@@ -48,7 +48,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/FileZilla.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleVersion</key>

--- a/WhatsAppInc/WhatsApp.download.recipe
+++ b/WhatsAppInc/WhatsApp.download.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/WhatsApp.app</string>
 				<key>requirement</key>
 				<string>identifier WhatsApp and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "57T9237FN3"</string>
 			</dict>

--- a/WhatsAppInc/WhatsApp.install.recipe
+++ b/WhatsAppInc/WhatsApp.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>WhatsApp.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/WhatsAppInc/WhatsApp.pkg.recipe
+++ b/WhatsAppInc/WhatsApp.pkg.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>app_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/WhatsApp.app</string>
 				<key>bundleid</key>
 				<string>com.whatsapp.WhatsApp</string>
 			</dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.