### PR TITLE
Python3: Use dynamic version_minor in MunkiInstallsItemsCreator

### DIFF
--- a/Python3/Python3.download.recipe
+++ b/Python3/Python3.download.recipe
@@ -19,6 +19,17 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
+				<string>(?P&lt;url&gt;https://.*/python-(?P&lt;version_minor&gt;3\.\d+)\.\d+.*\.pkg)</string>
+				<key>url</key>
+				<string>https://www.python.org/downloads/</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
 				<string>(?P&lt;url&gt;https://.*/python-(?P&lt;version&gt;3\.\d+\.\d+).*\.pkg)</string>
 				<key>url</key>
 				<string>https://www.python.org/downloads/</string>

--- a/Python3/Python3.munki.recipe
+++ b/Python3/Python3.munki.recipe
@@ -75,7 +75,7 @@
 				<string>%RECIPE_CACHE_DIR%/payload/</string>
 				<key>installs_item_paths</key>
 				<array>
-					<string>/Applications/Python 3.6/Python Launcher.app</string>
+					<string>/Applications/Python %version_minor%/Python Launcher.app</string>
 				</array>
 			</dict>
 			<key>Processor</key>


### PR DESCRIPTION
Current Python 3.7 will not be updated and also has an incomplete munki pkginfo, because it looks for CFBundleIdentifier in static `/Applications/Python 3.6/Python Launcher.app`.

I duplicated a `URLTextSearcher` processor to save the Python minor version in `%version_minor%` and use that instead.