### PR TITLE
Update EraseInstall.jss.recipe

### DIFF
--- a/ProWarehouse/EraseInstall.jss.recipe
+++ b/ProWarehouse/EraseInstall.jss.recipe
@@ -47,6 +47,8 @@
 						<string>%GROUP_TEMPLATE%</string>
 					</dict>
 				</array>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
 				<key>policy_category</key>
 				<string>%POLICY_CATEGORY%</string>
 				<key>policy_template</key>


### PR DESCRIPTION
Added:
```
				<key>pkg_path</key>
				<string>%pathname%</string>
```
Because the jss recipe won't grab any package without it.