### PR TITLE
Shellcheck: upstream release URL moved to github

### DIFF
--- a/Shellcheck/Shellcheck.download.recipe
+++ b/Shellcheck/Shellcheck.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://shellcheck.storage.googleapis.com/shellcheck-%download_version%.darwin.x86_64.tar.xz</string>
+				<string>https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-%download_version%.darwin.x86_64.tar.xz</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Shellcheck moved, when running the binary it said:

```
$ /Users/admin/Library/AutoPkg/Cache/local.munki.Shellcheck/Shellcheck/shellcheck-stable/shellcheck
You are downloading ShellCheck from an outdated URL!

Please update to the new URL:
https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.darwin.x86_64.tar.xz

For more information, see:
https://github.com/koalaman/shellcheck/issues/1871

PS: Sorry for breaking your build :(
```