### PR TITLE
Shellcheck: fix invalid variable in exception

### DIFF
--- a/Shellcheck/GetBinaryVersion.py
+++ b/Shellcheck/GetBinaryVersion.py
@@ -43,7 +43,7 @@ class GetBinaryVersion(Processor):
             re_pattern = re.compile(re_string)
             match = re_pattern.search(output)
             if not match:
-                raise ProcessorError("No match found on URL: %s" % url)
+                raise ProcessorError("No match found for version string in: %s" % output)
             return match.group(match.lastindex or 0)
         else:
             return output      


### PR DESCRIPTION
While investigating #56 we triggered an exception in the changed
exception. Probably just a copy and paste error here.

```
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 673, in process
    self.env = processor.process()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 480, in process
    self.main()
  File "/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.scriptingosx-recipes/Shellcheck/GetBinaryVersion.py", line 56, in main
    self.env["version"] = self.getVersion()
  File "/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.scriptingosx-recipes/Shellcheck/GetBinaryVersion.py", line 48, in getVersion
    raise ProcessorError("No match found on URL: %s" % url)
NameError: name 'url' is not defined
  File "/Library/AutoPkg/autopkglib/__init__.py", line 673, in process
    self.env = processor.process()
name 'url' is not defined
```