### PR TITLE
Update VMwareHorizonClient.download.recipe

### DIFF
--- a/VMwareHorizonClient/VMwareHorizonClient.download.recipe
+++ b/VMwareHorizonClient/VMwareHorizonClient.download.recipe
@@ -7,16 +7,7 @@
 	<key>Identifier</key>
 	<string>com.github.scriptingosx.download.VMwareHorizonClient</string>
 	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>VMware-Horizon-Client</string>
-		<key>SEARCH_PATTERN_PRODUCT_VERSION</key>
-		<string>/web/vmware/details\?downloadGroup=CART.*_MAC_[0-9]+&amp;productId=[0-9]+&amp;rPId=[0-9]+</string>
-		<key>SEARCH_PATTERN_DMG</key>
-		<string>https://download3.vmware.com/software/view/viewclients/CART.*/VMware-Horizon-Client-[\d\.\-]+\.dmg</string>
-		<key>SEARCH_URL_PRODUCT_VERSION</key>
-		<string>https://my.vmware.com/en/web/vmware/info/slug/desktop_end_user_computing/vmware_horizon_clients/5_0</string>
-	</dict>
+	<dict/>
 	<key>MinimumVersion</key>
 	<string>0.4.2</string>
 	<key>Process</key>
@@ -25,11 +16,17 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>%SEARCH_PATTERN_PRODUCT_VERSION%</string>
-				<key>result_output_var_name</key>
-				<string>download_url</string>
+				<string>{\"name\":\"VMware Horizon Client for macOS\",\"code\":\"(?P&lt;downloadGroup&gt;(?P&lt;clientGroup&gt;CART.*?)_MAC_[\d]+?)\",\"releaseDate\":\".*\",\"productId\":\".*\",\"releasePackageId\":\".*\",\"orderId\":.*}</string>
+				<!--
+					Example for 5.4.3:
+					{"name":"VMware Horizon Client for macOS","code":"CART21FQ1_MAC_543","releaseDate":"2020-07-09T07:00:00Z","productId":"863","releasePackageId":"47872","orderId":4} 
+				-->
 				<key>url</key>
-				<string>%SEARCH_URL_PRODUCT_VERSION%</string>
+				<string>https://my.vmware.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&amp;category=desktop_end_user_computing&amp;product=vmware_horizon_clients&amp;version=5_0&amp;dlgType=PRODUCT_BINARY</string>
+				<!--
+					Example for 5.4.3:
+					https://my.vmware.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&version=5_0&dlgType=PRODUCT_BINARY
+				-->
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
@@ -38,11 +35,19 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>%SEARCH_PATTERN_DMG%</string>
+				<string>VMware-Horizon-Client-.*\.dmg</string>
+				<!--
+					Example for 5.4.3:
+					VMware-Horizon-Client-5.4.3-16499473.dmg
+				-->
 				<key>result_output_var_name</key>
 				<string>dmg_url</string>
 				<key>url</key>
-				<string>https://my.vmware.com%download_url%</string>
+				<string>https://my.vmware.com/channel/public/api/v1.0/dlg/details?locale=en_US&amp;category=desktop_end_user_computing&amp;product=vmware_horizon_clients&amp;version=5_0&amp;dlgType=PRODUCT_BINARY&amp;downloadGroup=%downloadGroup%</string>
+				<!--
+					Example for 5.4.3:
+					https://my.vmware.com/channel/public/api/v1.0/dlg/details?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&version=5_0&dlgType=PRODUCT_BINARY&downloadGroup=CART21FQ1_MAC_543
+				-->
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
@@ -51,7 +56,11 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>%dmg_url%</string>
+				<string>https://download3.vmware.com/software/view/viewclients/%clientGroup%/%dmg_url%</string>
+				<!--
+					Example for 5.4.3:
+					https://download3.vmware.com/software/view/viewclients/CART21FQ1/VMware-Horizon-Client-5.4.3-16499473.dmg
+				-->
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Uses API calls to obtain the downloader, since the standard URLs are no longer accessible via CURL.