### PR TITLE
Fix whitespace in ShellCheck FileMover argument

### DIFF
--- a/Shellcheck/Shellcheck.pkg.recipe
+++ b/Shellcheck/Shellcheck.pkg.recipe
@@ -77,7 +77,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source</key>
-				<string>%destination_path%/shellcheck-v%version%/shellcheck </string>
+				<string>%destination_path%/shellcheck-v%version%/shellcheck</string>
 				<key>target</key>
 				<string>%pkgroot%/usr/local/bin/shellcheck</string>
 			</dict>


### PR DESCRIPTION
Running (uncached?) shellcheck.pkg failed for me with:

```
[Errno 2] No such file or directory: '/Users/krause/Library/AutoPkg/Cache/local.munki.Shellcheck/Shellcheck/shellcheck-v0.7.1/shellcheck ' -> '/Users/krause/Library/AutoPkg/Cache/local.munki.Shellcheck/Shellcheck/payload/usr/local/bin/shellcheck'
Failed.
Receipt written to /Users/krause/Library/AutoPkg/Cache/local.munki.Shellcheck/receipts/Shellcheck.munki-receipt-20201230-160459.plist

The following recipes failed:
    Shellcheck.munki.recipe
        Error in local.munki.Shellcheck: Processor: FileMover: Error: [Errno 2] No such file or directory: '/Users/krause/Library/AutoPkg/Cache/local.munki.Shellcheck/Shellcheck/shellcheck-v0.7.1/shellcheck ' -> '/Users/krause/Library/AutoPkg/Cache/local.munki.Shellcheck/Shellcheck/payload/usr/local/bin/shellcheck'

Nothing downloaded, packaged or imported.
```

Turns out there is an extra whitespace in the source argument of the `FileMover` Processor. Removing the whitespaced fixes the run for me:

```
[...]
 'pkgname': 'Shellcheck-0.7.1',
 'pkgroot': '/Users/krause/Library/AutoPkg/Cache/local.munki.Shellcheck/Shellcheck/payload',
 'prefetch_filename': False,
 'release_notes': 'This release is dedicated to the board game Pandemic, for '
                  'teaching us\r\n'
                  'relevant survival skills like how to stay inside and play '
                  'board games.',
 'repo_subdirectory': 'developer',
 'source': '/Users/krause/Library/AutoPkg/Cache/local.munki.Shellcheck/Shellcheck/shellcheck-v0.7.1/shellcheck',
 'target': '/Users/krause/Library/AutoPkg/Cache/local.munki.Shellcheck/Shellcheck/payload/usr/local/bin/shellcheck',
 'url': 'https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.darwin.x86_64.tar.xz',
 'verbose': 6,
 'version': '0.7.1'}
Receipt written to /Users/krause/Library/AutoPkg/Cache/local.munki.Shellcheck/receipts/Shellcheck.munki-receipt-20201230-160738.plist

The following packages were built:
    Identifier                       Version  Pkg Path                                                                         
    ----------                       -------  --------                                                                         
    com.scriptingosx.pkg.shellcheck  0.7.1    /Users/krause/Library/AutoPkg/Cache/local.munki.Shellcheck/Shellcheck-0.7.1.pkg  
```