### PR TITLE
fix shellcheck pkg/install recipes

### DIFF
--- a/Shellcheck/Shellcheck.install.recipe
+++ b/Shellcheck/Shellcheck.install.recipe
@@ -15,11 +15,6 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_path</key>
-				<string>%pathname%</string>
-			</dict>
 			<key>Processor</key>
 			<string>Installer</string>
 		</dict>

--- a/Shellcheck/Shellcheck.pkg.recipe
+++ b/Shellcheck/Shellcheck.pkg.recipe
@@ -77,7 +77,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source</key>
-				<string>%destination_path%/shellcheck-v%version%/shellcheck </string>
+				<string>%destination_path%/shellcheck-v%version%/shellcheck</string>
 				<key>target</key>
 				<string>%pkgroot%/usr/local/bin/shellcheck</string>
 			</dict>


### PR DESCRIPTION
My bad, pkg step was failing on a 'no such file or directory' due to trailing space, don't know how I missed it in the xml bracket 😅
Was also passing bad var (instead of correct, default one output'd from PkgCreator) to Installer