### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/AptanaStudio3/AptanaStudio3.pkg.recipe
+++ b/AptanaStudio3/AptanaStudio3.pkg.recipe
@@ -78,9 +78,9 @@
 					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>

--- a/Eclipse/EclipseKepler.pkg.recipe
+++ b/Eclipse/EclipseKepler.pkg.recipe
@@ -58,10 +58,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Fetch/Fetch_old.pkg.recipe
+++ b/Fetch/Fetch_old.pkg.recipe
@@ -72,10 +72,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/FileZilla/FileZilla.pkg.recipe
+++ b/FileZilla/FileZilla.pkg.recipe
@@ -63,10 +63,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/FirefoxPrefs/FirefoxPrefs.pkg.recipe
+++ b/FirefoxPrefs/FirefoxPrefs.pkg.recipe
@@ -118,9 +118,9 @@ combination is offered.</string>
 					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>

--- a/ImageJ/ImageJ.pkg.recipe
+++ b/ImageJ/ImageJ.pkg.recipe
@@ -122,9 +122,9 @@ rm -rf /Applications/ImageJ
 					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>

--- a/Shellcheck/Shellcheck.pkg.recipe
+++ b/Shellcheck/Shellcheck.pkg.recipe
@@ -110,9 +110,9 @@
 					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%/</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).