### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/BitTorrent/uTorrent.pkg.recipe
+++ b/BitTorrent/uTorrent.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.scriptingosx.pkg.uTorrent</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.bittorrent.uTorrent</string>
 		<key>NAME</key>
 		<string>uTorrent</string>
 	</dict>

--- a/Nomadesk/Nomadesk.pkg.recipe
+++ b/Nomadesk/Nomadesk.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.scriptingosx.pkg.Nomadesk</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.NomaDesk</string>
 		<key>NAME</key>
 		<string>Nomadesk</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ BitTorrent/uTorrent.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/scriptingosx-recipes/BitTorrent/uTorrent.pkg.recipe
Processing repos/scriptingosx-recipes/BitTorrent/uTorrent.pkg.recipe...
URLDownloader
{'Input': {'filename': 'uTorrent.dmg',
           'url': 'http://download.ap.bittorrent.com/track/stable/endpoint/utmac/os/osx'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 20 May 2020 11:33:00 +0000
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.scriptingosx.pkg.uTorrent/downloads/uTorrent.dmg
{'Output': {'download_changed': True,
            'last_modified': 'Wed, 20 May 2020 11:33:00 +0000',
            'pathname': '~/Library/AutoPkg/Cache/com.scriptingosx.pkg.uTorrent/downloads/uTorrent.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.scriptingosx.pkg.uTorrent/downloads/uTorrent.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.scriptingosx.pkg.uTorrent/downloads/uTorrent.dmg/uTorrent.app',
           'requirement': 'identifier "com.bittorrent.uTorrent" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'SNBT6M4A7T'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.scriptingosx.pkg.uTorrent/downloads/uTorrent.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.GFfSen/uTorrent.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.GFfSen/uTorrent.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.GFfSen/uTorrent.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.scriptingosx.pkg.uTorrent/downloads/uTorrent.dmg/uTorrent.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.scriptingosx.pkg.uTorrent/downloads/uTorrent.dmg
Versioner: Found version 1.8.7 in file /private/tmp/dmg.eYinHL/uTorrent.app/Contents/Info.plist
{'Output': {'version': '1.8.7'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.scriptingosx.pkg.uTorrent/downloads/uTorrent.dmg/uTorrent.app',
           'version': '1.8.7'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.scriptingosx.pkg.uTorrent/downloads/uTorrent.dmg
AppPkgCreator: BundleID: com.bittorrent.uTorrent
AppPkgCreator: Copied /private/tmp/dmg.bBtir0/uTorrent.app to ~/Library/AutoPkg/Cache/com.scriptingosx.pkg.uTorrent/payload/Applications/uTorrent.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.bittorrent.uTorrent',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.scriptingosx.pkg.uTorrent/uTorrent-1.8.7.pkg',
                                                        'version': '1.8.7'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.8.7'}}
Receipt written to ~/Library/AutoPkg/Cache/com.scriptingosx.pkg.uTorrent/receipts/uTorrent.pkg-receipt-20210213-221953.plist

The following new items were downloaded:
    Download Path                                                                              
    -------------                                                                              
    ~/Library/AutoPkg/Cache/com.scriptingosx.pkg.uTorrent/downloads/uTorrent.dmg  

The following packages were built:
    Identifier               Version  Pkg Path                                                                               
    ----------               -------  --------                                                                               
    com.bittorrent.uTorrent  1.8.7    ~/Library/AutoPkg/Cache/com.scriptingosx.pkg.uTorrent/uTorrent-1.8.7.pkg  
```

## ✅ Nomadesk/Nomadesk.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/scriptingosx-recipes/Nomadesk/Nomadesk.pkg.recipe
Processing repos/scriptingosx-recipes/Nomadesk/Nomadesk.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Nomadesk.dmg',
           'url': 'https://secure.nomadesk.com/download/?os=macosx'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.scriptingosx.pkg.Nomadesk/downloads/Nomadesk.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.scriptingosx.pkg.Nomadesk/downloads/Nomadesk.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.scriptingosx.pkg.Nomadesk/downloads/Nomadesk.dmg/Nomadesk.app',
           'requirement': 'identifier "com.NomaDesk" and anchor apple generic '
                          'and certificate 1[field.1.2.840.113635.100.6.2.6] '
                          '/* exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "8JY2P48JJZ"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.scriptingosx.pkg.Nomadesk/downloads/Nomadesk.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.zvuFHJ/Nomadesk.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.zvuFHJ/Nomadesk.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.zvuFHJ/Nomadesk.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.scriptingosx.pkg.Nomadesk/downloads/Nomadesk.dmg/Nomadesk.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.scriptingosx.pkg.Nomadesk/downloads/Nomadesk.dmg
Versioner: Found version 10.0.2 in file /private/tmp/dmg.r0aOAo/Nomadesk.app/Contents/Info.plist
{'Output': {'version': '10.0.2'}}
AppPkgCreator
{'Input': {'version': '10.0.2'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.scriptingosx.pkg.Nomadesk/downloads/Nomadesk.dmg
AppPkgCreator: Using path '/private/tmp/dmg.kjmJU9/Nomadesk.app' matched from globbed '/private/tmp/dmg.kjmJU9/*.app'.
AppPkgCreator: BundleID: com.NomaDesk
AppPkgCreator: Copied /private/tmp/dmg.kjmJU9/Nomadesk.app to ~/Library/AutoPkg/Cache/com.scriptingosx.pkg.Nomadesk/payload/Applications/Nomadesk.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.NomaDesk',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.scriptingosx.pkg.Nomadesk/Nomadesk-10.0.2.pkg',
                                                        'version': '10.0.2'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '10.0.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.scriptingosx.pkg.Nomadesk/receipts/Nomadesk.pkg-receipt-20210213-222022.plist

The following packages were built:
    Identifier    Version  Pkg Path                                                                                
    ----------    -------  --------                                                                                
    com.NomaDesk  10.0.2   ~/Library/AutoPkg/Cache/com.scriptingosx.pkg.Nomadesk/Nomadesk-10.0.2.pkg  
```

