### PR TITLE
Remove Munki-related input vars from ImageJ download and pkg recipes

### DIFF
--- a/ImageJ/ImageJ.download.recipe
+++ b/ImageJ/ImageJ.download.recipe
@@ -8,40 +8,8 @@
 	<string>com.github.scriptingosx.download.ImageJ</string>
 	<key>Input</key>
 	<dict>
-		<key>MUNKI_CATEGORY</key>
-		<string>Image Processing</string>
-		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps</string>
 		<key>NAME</key>
 		<string>ImageJ</string>
-		<key>pkginfo</key>
-		<dict>
-			<key>blocking_applications</key>
-			<array>
-				<string>ImageJ</string>
-			</array>
-			<key>catalogs</key>
-			<array>
-				<string>testing</string>
-			</array>
-			<key>category</key>
-			<string>%MUNKI_CATEGORY%</string>
-			<key>description</key>
-			<string>Image Processing and Analysis in Java. Open source software to read and write GIF, JPEG, and ASCII. Read BMP, DICOM, FITS, and more.</string>
-			<key>developer</key>
-			<string>Wayne Rasband</string>
-			<key>name</key>
-			<string>%NAME%</string>
-			<key>unattended_install</key>
-			<true/>
-			<key>uninstall_method</key>
-			<string>uninstall_script</string>
-			<key>uninstall_script</key>
-			<string>#!/bin/sh
-
-rm -rf /Applications/ImageJ
-</string>
-		</dict>
 	</dict>
 	<key>Process</key>
 	<array>

--- a/ImageJ/ImageJ.pkg.recipe
+++ b/ImageJ/ImageJ.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads ImageJ and imports into Munki.</string>
+	<string>Downloads ImageJ and builds a package.</string>
 	<key>Identifier</key>
 	<string>com.github.scriptingosx.pkg.ImageJ</string>
 	<key>Input</key>

--- a/ImageJ/ImageJ.pkg.recipe
+++ b/ImageJ/ImageJ.pkg.recipe
@@ -8,40 +8,8 @@
 	<string>com.github.scriptingosx.pkg.ImageJ</string>
 	<key>Input</key>
 	<dict>
-		<key>MUNKI_CATEGORY</key>
-		<string>Image Processing</string>
-		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps</string>
 		<key>NAME</key>
 		<string>ImageJ</string>
-		<key>pkginfo</key>
-		<dict>
-			<key>blocking_applications</key>
-			<array>
-				<string>ImageJ</string>
-			</array>
-			<key>catalogs</key>
-			<array>
-				<string>testing</string>
-			</array>
-			<key>category</key>
-			<string>%MUNKI_CATEGORY%</string>
-			<key>description</key>
-			<string>Image Processing and Analysis in Java. Open source software to read and write GIF, JPEG, and ASCII. Read BMP, DICOM, FITS, and more.</string>
-			<key>developer</key>
-			<string>Wayne Rasband</string>
-			<key>name</key>
-			<string>%NAME%</string>
-			<key>unattended_install</key>
-			<true/>
-			<key>uninstall_method</key>
-			<string>uninstall_script</string>
-			<key>uninstall_script</key>
-			<string>#!/bin/sh
-
-rm -rf /Applications/ImageJ
-</string>
-		</dict>
 	</dict>
 	<key>ParentRecipe</key>
 	<string>com.github.scriptingosx.download.ImageJ</string>


### PR DESCRIPTION
Neither of these recipes have a MunkiImporter process, so the Munki-related input variables serve no purpose and may cause confusion for admins who override the recipes.