### PR TITLE
Argument does not honor recipe override input

### DIFF
--- a/DjView/DjView.jss.recipe
+++ b/DjView/DjView.jss.recipe
@@ -18,7 +18,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>category</key>
-				<string>Productivity</string>
+				<string>%CATEGORY%</string>
 				<key>prod_name</key>
 				<string>%NAME%</string>
 				<key>version</key>


### PR DESCRIPTION
When autopkg recipe override runs, DjView package always uploads to Jamf with category "Productivity" regardless of CATEGORY key input.