### PR TITLE
Update VMware Horizon Client Munki recipe for new package based installer

### DIFF
--- a/VMwareHorizonClient/VMwareHorizonClient.download.recipe
+++ b/VMwareHorizonClient/VMwareHorizonClient.download.recipe
@@ -82,10 +82,14 @@ Version 8: horizon_8
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: VMware, Inc. (EG7KH642X6)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
 				<key>input_path</key>
-				<string>%pathname%/VMware Horizon Client.app</string>
-				<key>requirement</key>
-				<string>identifier "com.vmware.horizon" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EG7KH642X6</string>
+				<string>%pathname%/VMware Horizon Client.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/VMwareHorizonClient/VMwareHorizonClient.download.recipe
+++ b/VMwareHorizonClient/VMwareHorizonClient.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version Horizon Client for Mac.
+	<string>Downloads the latest version of VMWare Horizon Client for Mac.
 
 To download a specific major version, override the HORIZON_MAJOR_VERSION variable with a value below:
 

--- a/VMwareHorizonClient/VMwareHorizonClient.munki.recipe
+++ b/VMwareHorizonClient/VMwareHorizonClient.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>DESCRIPTION HERE!</string>
+	<string>Downloads the latest version of VMWare Horizon Client for Mac and imports into Munki.</string>
 	<key>Identifier</key>
 	<string>com.github.scriptingosx.munki.VMwareHorizonClient</string>
 	<key>Input</key>
@@ -25,9 +25,9 @@
 			<key>developer</key>
 			<string>VMware</string>
 			<key>display_name</key>
-			<string>VMware Horizon Client for Mac</string>
-			<key>name</key>
 			<string>VMware Horizon Client</string>
+			<key>name</key>
+			<string>VMwareHorizonClient</string>
 			<key>postinstall_script</key>
 			<string>#!/bin/sh
 /Applications/VMware\ Horizon\ Client.app/Contents/Library/InitUsbServices.tool
@@ -47,8 +47,83 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>flat_pkg_path</key>
+				<string>%pathname%/VMware Horizon Client.pkg</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack</string>
+			</dict>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/VMware.Horizon.Client.pkg/Payload</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload/Applications</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>derive_minimum_os_version</key>
+				<string>true</string>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%/payload</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/VMware Horizon Client.app</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload/Applications/VMware Horizon Client.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>pkg_path</key>
-				<string>%pathname%</string>
+				<string>%RECIPE_CACHE_DIR%/VMwareHorizonClient.pkg</string>
+				<key>source_pkg</key>
+				<string>%pathname%/VMware Horizon Client.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pkg_path%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>


### PR DESCRIPTION
Forks @Daz-wallace https://github.com/autopkg/scriptingosx-recipes/pull/90 to include an updated `CodeSignatureVerifier` processor as well.

VMware moved from drag and drop DMG to a package. This gets the embedded .app version, copies the package from the DMG, and imports into Munki. Should be a seamless change for those already using the existing recipe. 