### PR TITLE
Update WhatsApp.download.recipe

### DIFF
--- a/WhatsAppInc/WhatsApp.download.recipe
+++ b/WhatsAppInc/WhatsApp.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>https://web.whatsapp.com/desktop/mac/files/WhatsApp.dmg</string>
+		<string>https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release</string>
 		<key>NAME</key>
 		<string>WhatsApp</string>
 	</dict>
@@ -40,7 +40,7 @@
 				<key>input_path</key>
 				<string>%pathname%/WhatsApp.app</string>
 				<key>requirement</key>
-				<string>identifier WhatsApp and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "57T9237FN3"</string>
+				<string>identifier "net.whatsapp.WhatsApp" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "57T9237FN3"</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Hi, @scriptingosx 

The WhatsApp download recipe is picking up an outdated intel version of the App. 

This PR updates to the latest download URL to grab the Universal app and has a new code signature. 

Output from a successful run

```
WhatsAppInc % autopkg run -v WhatsApp.munki.recipe 
Looking for com.scriptingosx.download.WhatsApp...
Did not find com.scriptingosx.download.WhatsApp in recipe map
Rebuilding recipe map with current working directories...
Looking for com.scriptingosx.download.WhatsApp...
Found com.scriptingosx.download.WhatsApp in recipe map
**load_recipe time: 0.004463499994017184
Processing WhatsApp.munki.recipe...
WARNING: WhatsApp.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 27 Sep 2023 23:56:22 GMT
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.scriptingosx.munki.WhatsApp/downloads/WhatsApp.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.scriptingosx.munki.WhatsApp/downloads/WhatsApp.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.5bjRk3/WhatsApp.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.5bjRk3/WhatsApp.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.5bjRk3/WhatsApp.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
AppDmgVersioner
AppDmgVersioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.scriptingosx.munki.WhatsApp/downloads/WhatsApp.dmg
AppDmgVersioner: BundleID: net.whatsapp.WhatsApp
AppDmgVersioner: Version: 23.19.86
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/WhatsApp/WhatsApp-23.19.86.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/WhatsApp/WhatsApp-23.19.86.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.scriptingosx.munki.WhatsApp/receipts/WhatsApp.munki-receipt-20230929-160946.plist

The following new items were downloaded:
    Download Path                                                                                    
    -------------                                                                                    
    /Users/paul.cossey/Library/AutoPkg/Cache/com.scriptingosx.munki.WhatsApp/downloads/WhatsApp.dmg  

The following new items were imported into Munki:
    Name      Version   Catalogs  Pkginfo Path                           Pkg Repo Path                        Icon Repo Path  
    ----      -------   --------  ------------                           -------------                        --------------  
    WhatsApp  23.19.86  testing   apps/WhatsApp/WhatsApp-23.19.86.plist  apps/WhatsApp/WhatsApp-23.19.86.dmg
```