### PR TITLE
Deprecate erase-install.download and change parent for erase-install.munki

### DIFF
--- a/ProWarehouse/EraseInstall.download.recipe
+++ b/ProWarehouse/EraseInstall.download.recipe
@@ -14,9 +14,18 @@
 		<string>https://bitbucket.org/prowarehouse-nl/erase-install/downloads</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the erase-install recipes in the grahampugh-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/ProWarehouse/EraseInstall.munki.recipe
+++ b/ProWarehouse/EraseInstall.munki.recipe
@@ -31,7 +31,7 @@
 	<key>MinimumVersion</key>
 	<string>1.0</string>
 	<key>ParentRecipe</key>
-	<string>com.scriptingosx.download.EraseInstall</string>
+	<string>com.github.grahampugh.recipes.download.erase-install</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
To simplify recipe searches, this PR deprecates the non-functional erase-install download recipe in this repo.

The erase-install munki recipe has been modified to use the grahampugh-recipes download recipe as its parent.

