### PR TITLE
Deprecate Eclipse Kepler recipes

### DIFF
--- a/Eclipse/EclipseKepler.download.recipe
+++ b/Eclipse/EclipseKepler.download.recipe
@@ -12,9 +12,18 @@
         <string>EclipseKepler</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Eclipse Kepler was published in 2013. For newer Eclipse releases, consider switching to the Eclipse recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
This PR deprecates the Eclipse Kepler recipes, and points users to newer versions of Eclipse via the recipes in my homebysix-recipes repo.