### PR TITLE
Fix IMOD recipes

### DIFF
--- a/Bio3DColorado/IMOD.download.recipe
+++ b/Bio3DColorado/IMOD.download.recipe
@@ -3,11 +3,18 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of IMOD.</string>
+	<string>Downloads the latest version of IMOD.
+
+Valid values for ARCH include:
+- "intel" (default, Intel)
+- "arm64" (Apple Silicon)
+</string>
 	<key>Identifier</key>
 	<string>com.github.scriptingosx.download.IMOD</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>intel</string>
 		<key>NAME</key>
 		<string>IMOD</string>
 	</dict>
@@ -19,7 +26,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;osx/(?P&lt;scriptname&gt;imod_(?P&lt;version&gt;\d+\.\d+\.\d+)_osx64_(?P&lt;osx_version&gt;10\.\d+)_(?P&lt;cuda_version&gt;CUDA\d+\.\d+)\..*sh))</string>
+				<string>(osx/imod_[\d\.]+(_osx\d+)?_%ARCH%\.pkg)</string>
 				<key>result_output_var_name</key>
 				<string>url</string>
 				<key>url</key>
@@ -40,6 +47,21 @@
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: David Mastronarde (JNF2CPUCK9)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+				<key>input_path</key>
+				<string>%pathname%</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
This PR updates the IMOD recipes with a new file pattern and code signature verification.

Verbose recipe run with default (Intel) architecture:

```
% autopkg run -vvq '~/Developer/repo-lasso/repos/autopkg/scriptingosx-recipes/Bio3DColorado/IMOD.download.recipe'
Processing ~/Developer/repo-lasso/repos/autopkg/scriptingosx-recipes/Bio3DColorado/IMOD.download.recipe...
WARNING: ~/Developer/repo-lasso/repos/autopkg/scriptingosx-recipes/Bio3DColorado/IMOD.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(osx/imod_[\\d\\.]+(_osx\\d+)?_intel\\.pkg)',
           'result_output_var_name': 'url',
           'url': 'http://bio3d.colorado.edu/imod/download.html'}}
URLTextSearcher: Found matching text (url): osx/imod_5.1.0_osx11_intel.pkg
{'Output': {'url': 'osx/imod_5.1.0_osx11_intel.pkg'}}
URLDownloader
{'Input': {'url': 'http://bio3d.colorado.edu/imod/osx/imod_5.1.0_osx11_intel.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 12 Dec 2024 10:28:58 GMT
URLDownloader: Storing new ETag header: "3c9dfd4-629102ea312d3"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.scriptingosx.download.IMOD/downloads/imod_5.1.0_osx11_intel.pkg
{'Output': {'download_changed': True,
            'etag': '"3c9dfd4-629102ea312d3"',
            'last_modified': 'Thu, 12 Dec 2024 10:28:58 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.scriptingosx.download.IMOD/downloads/imod_5.1.0_osx11_intel.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.scriptingosx.download.IMOD/downloads/imod_5.1.0_osx11_intel.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: David '
                                        'Mastronarde (JNF2CPUCK9)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.scriptingosx.download.IMOD/downloads/imod_5.1.0_osx11_intel.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "imod_5.1.0_osx11_intel.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-12-12 10:28:31 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: David Mastronarde (JNF2CPUCK9)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            65 35 93 E2 43 53 35 4A A7 41 94 82 D8 26 9E BB 9F 1D C9 D5 6D 8A
CodeSignatureVerifier:            3A 0E A3 71 4F DC 16 C4 6F 79
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.scriptingosx.download.IMOD/receipts/IMOD.download-receipt-20241230-125658.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.scriptingosx.download.IMOD/downloads/imod_5.1.0_osx11_intel.pkg
```

Verbose recipe run with Apple Silicon architecture:

```
% autopkg run -vvq '~/Developer/repo-lasso/repos/autopkg/scriptingosx-recipes/Bio3DColorado/IMOD.download.recipe' -k ARCH=arm64
Processing ~/Developer/repo-lasso/repos/autopkg/scriptingosx-recipes/Bio3DColorado/IMOD.download.recipe...
WARNING: ~/Developer/repo-lasso/repos/autopkg/scriptingosx-recipes/Bio3DColorado/IMOD.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(osx/imod_[\\d\\.]+(_osx\\d+)?_arm64\\.pkg)',
           'result_output_var_name': 'url',
           'url': 'http://bio3d.colorado.edu/imod/download.html'}}
URLTextSearcher: Found matching text (url): osx/imod_5.1.0_osx11_arm64.pkg
{'Output': {'url': 'osx/imod_5.1.0_osx11_arm64.pkg'}}
URLDownloader
{'Input': {'url': 'http://bio3d.colorado.edu/imod/osx/imod_5.1.0_osx11_arm64.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 12 Dec 2024 08:45:25 GMT
URLDownloader: Storing new ETag header: "2843fd6-6290ebc4f75db"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.scriptingosx.download.IMOD/downloads/imod_5.1.0_osx11_arm64.pkg
{'Output': {'download_changed': True,
            'etag': '"2843fd6-6290ebc4f75db"',
            'last_modified': 'Thu, 12 Dec 2024 08:45:25 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.scriptingosx.download.IMOD/downloads/imod_5.1.0_osx11_arm64.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.scriptingosx.download.IMOD/downloads/imod_5.1.0_osx11_arm64.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: David '
                                        'Mastronarde (JNF2CPUCK9)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.scriptingosx.download.IMOD/downloads/imod_5.1.0_osx11_arm64.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "imod_5.1.0_osx11_arm64.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-12-12 08:44:54 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: David Mastronarde (JNF2CPUCK9)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            65 35 93 E2 43 53 35 4A A7 41 94 82 D8 26 9E BB 9F 1D C9 D5 6D 8A
CodeSignatureVerifier:            3A 0E A3 71 4F DC 16 C4 6F 79
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.scriptingosx.download.IMOD/receipts/IMOD.download-receipt-20241230-125705.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.scriptingosx.download.IMOD/downloads/imod_5.1.0_osx11_arm64.pkg
```
