### PR TITLE
Deprecate VMWare Horizon Client Recipes

### DIFF
--- a/VMwareHorizonClient/VMwareHorizonClient.download.recipe
+++ b/VMwareHorizonClient/VMwareHorizonClient.download.recipe
@@ -19,9 +19,29 @@ Version 8: horizon_8
 		<string>horizon_8</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.2</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe has been deprecated. VMWare Horizon Client has been replaced with Omnissa Horizon Client.
+
+Please use the new recipes located here: https://github.com/autopkg/dataJAR-recipes/tree/master/Omnissa%20Horizon%20Client </string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>predicate</key>
+				<string>TRUEPREDICATE</string>
+			</dict>
+			<key>Processor</key>
+			<string>StopProcessingIf</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
@@ -29,7 +49,7 @@ Version 8: horizon_8
 				<string>{\"name\":\"VMware Horizon Client for macOS\",\"code\":\"(?P&lt;downloadGroup&gt;(?P&lt;clientGroup&gt;CART.*?)_MAC_.*?)\",\"releaseDate\":\".*\",\"productId\":\".*\",\"releasePackageId\":\".*\",\"isFirmwareImage\":.*,\"orderId\":.*}</string>
 				<!--
 					Example for 5.4.3:
-					{"name":"VMware Horizon Client for macOS","code":"CART21FQ1_MAC_543","releaseDate":"2020-07-09T07:00:00Z","productId":"863","releasePackageId":"47872","orderId":4} 
+					{"name":"VMware Horizon Client for macOS","code":"CART21FQ1_MAC_543","releaseDate":"2020-07-09T07:00:00Z","productId":"863","releasePackageId":"47872","orderId":4}
 				-->
 				<key>url</key>
 				<string>https://customerconnect.omnissa.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&amp;category=desktop_end_user_computing&amp;product=vmware_horizon_clients&amp;version=%HORIZON_MAJOR_VERSION%&amp;dlgType=PRODUCT_BINARY</string>

--- a/VMwareHorizonClient/VMwareHorizonClient.munki.recipe
+++ b/VMwareHorizonClient/VMwareHorizonClient.munki.recipe
@@ -39,11 +39,31 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.3</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.scriptingosx.download.VMwareHorizonClient</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe has been deprecated. VMWare Horizon Client has been replaced with Omnissa Horizon Client.
+
+Please use the new recipes located here: https://github.com/autopkg/dataJAR-recipes/tree/master/Omnissa%20Horizon%20Client </string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>predicate</key>
+				<string>TRUEPREDICATE</string>
+			</dict>
+			<key>Processor</key>
+			<string>StopProcessingIf</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Hi, @scriptingosx 

The VMWare Horizon Client recipes are now non-functional after the product sale to Omnissa. Omnissa has released a new rebranded version that includes a new Names and bundle ID.

This PR deprecates the recipes and points to new ones located in the [dataJAR-recipes repo](https://github.com/autopkg/dataJAR-recipes/tree/master/Omnissa%20Horizon%20Client). 

This PR 
- supersedes https://github.com/autopkg/scriptingosx-recipes/pull/104 
- resolves https://github.com/autopkg/scriptingosx-recipes/issues/109
- resolves https://github.com/autopkg/scriptingosx-recipes/issues/100
- resolves https://github.com/autopkg/scriptingosx-recipes/issues/95

Output from a successful -v run 
```
autopkg run -v VMwareHorizonClient.munki.recipe 
Looking for com.github.scriptingosx.download.VMwareHorizonClient...
Did not find com.github.scriptingosx.download.VMwareHorizonClient in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.scriptingosx.download.VMwareHorizonClient...
Found com.github.scriptingosx.download.VMwareHorizonClient in recipe map
**load_recipe time: 0.007148042001063004
Processing VMwareHorizonClient.munki.recipe...
WARNING: VMwareHorizonClient.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
DeprecationWarning
DeprecationWarning: This recipe has been deprecated. VMWare Horizon Client has been replaced with Omnissa Horizon Client.

Please use the new recipes located here: https://github.com/autopkg/dataJAR-recipes/tree/master/Omnissa%20Horizon%20Client 
StopProcessingIf
StopProcessingIf: (TRUEPREDICATE) is True
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.scriptingosx.munki.VMwareHorizonClient/receipts/VMwareHorizonClient.munki-receipt-20250121-124730.plist

The following recipes have deprecation warnings:
    Name                       Warning                                                                                                                                                                                                                             
    ----                       -------                                                                                                                                                                                                                             
    VMwareHorizonClient.munki  This recipe has been deprecated. VMWare Horizon Client has been replaced with Omnissa Horizon Client.

Please use the new recipes located here: https://github.com/autopkg/dataJAR-recipes/tree/master/Omnissa%20Horizon%20Client
```