### PR TITLE
Update TeXLiveUtility.munki.recipe

### DIFF
--- a/TeXLiveUtility/TeXLiveUtility.download.recipe
+++ b/TeXLiveUtility/TeXLiveUtility.download.recipe
@@ -45,6 +45,46 @@
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkgdirs</key>
+				<dict>
+					<key>Applications</key>
+					<string>0775</string>
+					<key>Applications/TeX</key>
+					<string>0775</string>
+				</dict>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgRootCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>archive_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%pkgroot%/Applications/TeX</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pkgroot%/Applications/TeX/TeX Live Utility.app</string>
+				<key>requirement</key>
+				<string>identifier "com.googlecode.mactlmgr.tlu" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "966Z24PX4J"</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/TeXLiveUtility/TeXLiveUtility.munki.recipe
+++ b/TeXLiveUtility/TeXLiveUtility.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Uploads TexLiveUtility into Munki</string>
+	<string>Uploads TexLiveUtility into Munki
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
 	<key>Identifier</key>
 	<string>com.github.scriptingosx.munki.TeXLiveUtility</string>
 	<key>Input</key>
 	<dict>
+		<key>DERIVE_MIN_OS</key>
+		<string>YES</string>
 		<key>MUNKI_CATEGORY</key>
 		<string>TeX</string>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -33,11 +37,42 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.3</string>
+	<string>2.7</string>
 	<key>ParentRecipe</key>
 	<string>com.github.scriptingosx.pkg.TeXLiveUtility</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/TeX/TeX Live Utility.app</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/TeXLiveUtility/TeXLiveUtility.pkg.recipe
+++ b/TeXLiveUtility/TeXLiveUtility.pkg.recipe
@@ -17,35 +17,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgdirs</key>
-				<dict>
-					<key>Applications</key>
-					<string>0775</string>
-					<key>Applications/TeX</key>
-					<string>0775</string>
-				</dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-			</dict>
-			<key>Processor</key>
-			<string>PkgRootCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%pkgroot%/Applications/TeX</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>info_path</key>
 				<string>%pkgroot%/Applications/TeX/TeX Live Utility.app</string>
 				<key>plist_keys</key>


### PR DESCRIPTION
Hi, @scriptingosx 

This PR adds in MunkiInstallsItemsCreator to create an installs array with derive_minimum_os_version.

Output from a -v run
```
autopkg run -v TeXLiveUtility.munki.recipe
Looking for com.github.scriptingosx.pkg.TeXLiveUtility...
Did not find com.github.scriptingosx.pkg.TeXLiveUtility in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.scriptingosx.pkg.TeXLiveUtility...
Found com.github.scriptingosx.pkg.TeXLiveUtility in recipe map
Looking for com.github.scriptingosx.download.TeXLiveUtility...
Found com.github.scriptingosx.download.TeXLiveUtility in recipe map
**load_recipe time: 0.017127333994721994
Processing TeXLiveUtility.munki.recipe...
WARNING: TeXLiveUtility.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Selected asset 'TeX.Live.Utility.app-1.54.zip' from tag '1.54' at url https://github.com/amaxwell/tlutility/releases/download/1.54/TeX.Live.Utility.app-1.54.zip
URLDownloader
URLDownloader: Storing new Last-Modified header: Sat, 18 Feb 2023 22:52:43 GMT
URLDownloader: Storing new ETag header: "0x8DB1202D8BA44D1"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.scriptingosx.munki.TeXLiveUtility/downloads/TeX.Live.Utility.app-1.54.zip
EndOfCheckPhase
PkgRootCreator
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.scriptingosx.munki.TeXLiveUtility/TeXLiveUtility
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.scriptingosx.munki.TeXLiveUtility/TeXLiveUtility/Applications
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.scriptingosx.munki.TeXLiveUtility/TeXLiveUtility/Applications/TeX
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename TeX.Live.Utility.app-1.54.zip
Unarchiver: Unarchived /Users/paul.cossey/Library/AutoPkg/Cache/com.github.scriptingosx.munki.TeXLiveUtility/downloads/TeX.Live.Utility.app-1.54.zip to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.scriptingosx.munki.TeXLiveUtility/TeXLiveUtility/Applications/TeX
PlistReader
PlistReader: Reading: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.scriptingosx.munki.TeXLiveUtility/TeXLiveUtility/Applications/TeX/TeX Live Utility.app/Contents/Info.plist
PlistReader: Assigning value of 'com.googlecode.mactlmgr.tlu' to output variable 'bundle_id'
PlistReader: Assigning value of '1.54' to output variable 'version'
PkgCreator
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/TeX/TeX Live Utility.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.9.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.googlecode.mactlmgr.tlu', 'CFBundleName': 'TeX Live Utility', 'CFBundleShortVersionString': '1.54', 'CFBundleVersion': '1.54', 'minosversion': '10.9.0', 'path': '/Applications/TeX/TeX Live Utility.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.9.0'} into pkginfo
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '1.54'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/TeXLiveUtility/TeXLiveUtility-1.54.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/TeXLiveUtility/TeXLiveUtility-1.54.pkg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.scriptingosx.munki.TeXLiveUtility/receipts/TeXLiveUtility.munki-receipt-20250422-123735.plist

The following new items were downloaded:
    Download Path                                                                                                                  
    -------------                                                                                                                  
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.scriptingosx.munki.TeXLiveUtility/downloads/TeX.Live.Utility.app-1.54.zip  

The following packages were built:
    Identifier                   Version  Pkg Path                                                                                                       
    ----------                   -------  --------                                                                                                       
    com.googlecode.mactlmgr.tlu  1.54     /Users/paul.cossey/Library/AutoPkg/Cache/com.github.scriptingosx.munki.TeXLiveUtility/TeXLiveUtility-1.54.pkg  

The following new items were imported into Munki:
    Name            Version  Catalogs  Pkginfo Path                                   Pkg Repo Path                                Icon Repo Path  
    ----            -------  --------  ------------                                   -------------                                --------------  
    TeXLiveUtility  1.54     testing   apps/TeXLiveUtility/TeXLiveUtility-1.54.plist  apps/TeXLiveUtility/TeXLiveUtility-1.54.pkg  
```